### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/BUILD_OPENTELEMETRY-COLLECTOR.md
+++ b/BUILD_OPENTELEMETRY-COLLECTOR.md
@@ -27,14 +27,14 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
   telemetry:
     metrics:
       level: none


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037